### PR TITLE
Interpret multiple moods as a single mood number - resolves #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Python compiled binaries.
 __pycache__/
-*.pyc
 
 # Python virtual environment.
 venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python compiled binaries.
 __pycache__/
+*.pyc
 
 # Python virtual environment.
 venv

--- a/dayliopy/clean_csv.py
+++ b/dayliopy/clean_csv.py
@@ -8,7 +8,7 @@ import codecs
 import csv
 import datetime
 
-from lib.config import AppConf
+from .lib.config import AppConf
 
 
 conf = AppConf()
@@ -41,8 +41,9 @@ def to_dt(date: str, time: str) -> datetime.datetime:
     return datetime.datetime.strptime(dt_str, dt_format)
 
 
+
 def interpret_moods() -> dict[str, int]:
-    result: dict[str, int] = {}
+    result = {}
     for key in conf.MOODS.keys():
         for mood in key.split(","):
             result[mood.strip()] = conf.MOODS[key]

--- a/dayliopy/clean_csv.py
+++ b/dayliopy/clean_csv.py
@@ -40,12 +40,14 @@ def to_dt(date: str, time: str) -> datetime.datetime:
 
     return datetime.datetime.strptime(dt_str, dt_format)
 
+
 def interpret_moods() -> dict[str, int]:
     result: dict[str, int] = {}
     for key in conf.MOODS.keys():
-        for mood in key.split(','):
+        for mood in key.split(","):
             result[mood.strip()] = conf.MOODS[key]
     return result
+
 
 def get_score(mood: str, interpreted_moods: dict[str, int]) -> int:
     """
@@ -83,7 +85,9 @@ def format_row(row: dict[str, str], datetime_obj, mood: str, mood_score: int) ->
 
 
 def clean_row(
-    row: dict[str, str], default_activities: dict[str, int], interpreted_moods: dict[str, int]
+    row: dict[str, str],
+    default_activities: dict[str, int],
+    interpreted_moods: dict[str, int],
 ) -> dict[str, str]:
     """
     Expect a CSV row and default activities and return cleaned row.
@@ -159,7 +163,7 @@ def clean_daylio_data(available_activities: set, in_data: list[dict[str, str]]):
     Convert Daylio CSV file to a more usable CSV report.
     """
     default_activities = {key: 0 for key in available_activities}
-    moods: dict[str: int] = interpret_moods()
+    moods: dict[str:int] = interpret_moods()
     out_data = [clean_row(row, default_activities.copy(), moods) for row in in_data]
 
     out_fields = CSV_OUT_FIELDS.copy()

--- a/dayliopy/clean_csv.py
+++ b/dayliopy/clean_csv.py
@@ -164,7 +164,7 @@ def clean_daylio_data(available_activities: set, in_data: list[dict[str, str]]):
     Convert Daylio CSV file to a more usable CSV report.
     """
     default_activities = {key: 0 for key in available_activities}
-    moods: dict[str:int] = interpret_moods()
+    moods = interpret_moods()
     out_data = [clean_row(row, default_activities.copy(), moods) for row in in_data]
 
     out_fields = CSV_OUT_FIELDS.copy()

--- a/dayliopy/etc/app.conf
+++ b/dayliopy/etc/app.conf
@@ -20,7 +20,8 @@ db_dir: %(var_dir)s/data_out/db.sqlite
 
 
 [daylio]
-# Labels for high to low moods. Comma separate if you use Daylio Pro's multiple moods feature. 
+# Labels for high to low moods. 
+# Use comma-separated values if you use Daylio Pro's multiple moods feature. 
 # In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
 mood5: rad
 mood4: good

--- a/dayliopy/etc/app.conf
+++ b/dayliopy/etc/app.conf
@@ -20,7 +20,8 @@ db_dir: %(var_dir)s/data_out/db.sqlite
 
 
 [daylio]
-# Labels for high to low moods.
+# Labels for high to low moods. Comma separate if you use Daylio Pro's multiple moods feature. 
+# In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
 mood5: rad
 mood4: good
 mood3: meh

--- a/dayliopy/etc/app.template.conf
+++ b/dayliopy/etc/app.template.conf
@@ -6,6 +6,9 @@
 # Labels for high to low moods. 
 # Use comma-separated values if you use Daylio Pro's multiple moods feature. 
 # In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
+# See moods 2 - 4 below as an example that match sample_multiple_moods.csv
 mood5: amazing
-mood2: sad
+mood4: good, Refreshed
+mood3: OK, ok but sleepy
+mood2: sad, bad, Anxious
 mood1: horrible

--- a/dayliopy/etc/app.template.conf
+++ b/dayliopy/etc/app.template.conf
@@ -3,7 +3,8 @@
 #
 
 [daylio]
-# Labels for high to low moods. Comma separate if you use Daylio Pro's multiple moods feature. 
+# Labels for high to low moods. 
+# Use comma-separated values if you use Daylio Pro's multiple moods feature. 
 # In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
 mood5: amazing
 mood2: sad

--- a/dayliopy/etc/app.template.conf
+++ b/dayliopy/etc/app.template.conf
@@ -1,14 +1,9 @@
-
-# Local config file.
-#
+# Local config file
 
 [daylio]
-# Labels for high to low moods. 
-# Use comma-separated values if you use Daylio Pro's multiple moods feature. 
-# In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
-# See moods 2 - 4 below as an example that match sample_multiple_moods.csv
-mood5: amazing
-mood4: good, Refreshed
-mood3: OK, ok but sleepy
-mood2: sad, bad, Anxious
-mood1: horrible
+# Labels for high to low moods. See Configuration in docs for help.
+# mood5:
+# mood4:
+# mood3: 
+# mood2:
+# mood1:

--- a/dayliopy/etc/app.template.conf
+++ b/dayliopy/etc/app.template.conf
@@ -3,7 +3,8 @@
 #
 
 [daylio]
-# Labels for high to low moods.
+# Labels for high to low moods. Comma separate if you use Daylio Pro's multiple moods feature. 
+# In that case, make sure not to use "," in your mood title. Rename it in Daylio first.
 mood5: amazing
 mood2: sad
 mood1: horrible

--- a/dayliopy/sample_multiple_moods.csv
+++ b/dayliopy/sample_multiple_moods.csv
@@ -1,0 +1,8 @@
+full_date,date,weekday,time,mood,activities,note_title,note
+2021-05-12,12 May,Wednesday,18:52,OK,"work","",""
+2021-05-12,12 May,Wednesday,15:40,OK,"work","",""
+2020-08-31,31 August,Monday,08:13,Refreshed,"Sleeping ","",""
+2020-08-28,28 August,Friday,20:01,good,"movies | good meal","",""
+2020-08-25,25 August,Tuesday,17:08,ok but sleepy,"work","",""
+2020-07-21,21 July,Tuesday,10:31,bad,"","",""
+2020-07-21,21 July,Tuesday,07:31,Anxious,"Sleeping ","",""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
-
 # Configuration
+
+
+## Config files 
 
 This project uses Python's built-in [ConfigParser](https://docs.python.org/3/library/configparser.html) format, which is easy for end-users to edit.
 
@@ -23,8 +25,28 @@ Or use the template as a starting point:
 $ cp dayliopy/etc/app.template.conf dayliopy/etc/app.local.conf
 ```
 
-Even though the _Daylio_ mobile app does allow more, a maximum of 5 mood levels is allowed in this application. Any others will raise an error.
 
-You must set the moods in the `[daylio]` section to exact match the labels in your CSV.
+## Configuring moods
 
-e.g. the configured default for `mood3` is `meh`, based on Daylio default. But if you configured Daylio to use `happy` for `mood3`, then you must also set that in `app.local.conf`.
+The Daylio app lets you override the labels for moods, which then appears in your export.
+
+If you do that, you need to configure this Dayliopy tool to know which level from 1 to 5 corresponds to that label.
+
+So set the moods in the `[daylio]` section to exactly match the labels in your CSV. You only need to set values in the local config if they differ from the base config.
+
+e.g. You can replace mood level 3 from "meh" default in Daylio with "average".
+
+```ini
+[daylio]
+mood3: average 
+```
+
+e.g. If you use multiple labels for the same level, you can configure this in the config too.
+
+```ini
+mood5: amazing
+mood4: good, refreshed
+mood3: ok, ok but sleepy
+mood2: sad, bad, anxious
+mood1: horrible
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,14 +34,18 @@ If you do that, you need to configure this Dayliopy tool to know which level fro
 
 So set the moods in the `[daylio]` section to exactly match the labels in your CSV. You only need to set values in the local config if they differ from the base config.
 
-e.g. You can replace mood level 3 from "meh" default in Daylio with "average".
+### Basic
+
+You could replace mood level 3 from "meh" default in Daylio with "average".
 
 ```ini
 [daylio]
 mood3: average 
 ```
 
-e.g. If you use multiple labels for the same level, you can configure this in the config too.
+### Multiple moods
+
+If you use more than 5 moods and want to map multiple labels for the same level, you can configure this in the config too.
 
 ```ini
 mood5: amazing
@@ -50,3 +54,7 @@ mood3: ok, ok but sleepy
 mood2: sad, bad, anxious
 mood1: horrible
 ```
+
+Note use of comma and optional space to separate values.
+
+NB. Make sure in the Daylio app to take out any commas from the mood label, to avoid issues here.


### PR DESCRIPTION
I don't know why I need the change in line 11 dayliopy/clean_csv.py - without that change I got `ImportError: attempted relative import with no known parent package`.

I passed the interpreted_moods result in down the methods to avoid running that every row. Over optimisation but whatever.  It's not like the extra 3-5 minutes it took to refactor that will ever be saved in run time, haha. Otherwise you can just call the method itself at line 58 and clean up the parameters.

I had trouble running the make commands even in WSL - it wanted pip3 and other things I forgot. So I just ran the Python scripts directly like in your earlier version. Now it produces me a cleaned.csv with my multiple moods! Your existing error handling still works with my implementation too, so it shows the same message if it encounters a mood string it doesn't recognise. I'm actually surprised that works as well as it does.

Actually, I just tried swapping `conf.MOODS` for `interpreted_moods` on line 63. (uncommited) I get:
`KeyError: "Each mood label in your CSV must be added to a conf file so that it can be assigned a numeric value. Not found: blah. Configured moods: {'awful': 1, 'bad': 2, 'sleepy': 2, 'Anxious': 2, 'ok': 3, 'ok but sleepy': 3, 'OK': 3, 'good': 4, 'Refreshed': 4, 'great': 5}"`

but I'm not sure if that's clearer than the original of: 
`KeyError: "Each mood label in your CSV must be added to a conf file so that it can be assigned a numeric value. Not found: blah. Configured moods: {'awful': 1, 'bad, sleepy, Anxious': 2, 'ok, ok but sleepy, OK': 3, 'good, Refreshed': 4, 'great': 5}"`

It's a bit clearer, I guess.